### PR TITLE
add strict ocp version to test

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -12,3 +12,5 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  # Annotations to specify OCP version
+  com.redhat.openshift.versions: "v4.8"


### PR DESCRIPTION
Specify OCP version 4.8 and above  in openshift community operator test suite.