### PR TITLE
review portmask calculation

### DIFF
--- a/controllers/stsconfig_controller.go
+++ b/controllers/stsconfig_controller.go
@@ -83,19 +83,19 @@ func (r *StsConfigReconciler) interfacesToBitmask(cfg *StsConfigTemplate, interf
 
 	for _, x := range interfaces {
 		if x.SyncE == 1 {
-			cfg.SyncePortMask |= (1 << x.EthPort)
+			cfg.SyncePortMask |= (1 << (x.EthPort-1))
 		}
 		if x.Ipv6 == 1 {
-			cfg.Ipv6PortMask |= (1 << x.EthPort)
+			cfg.Ipv6PortMask |= (1 << (x.EthPort-1))
 		}
 		if x.Ipv4 == 1 {
-			cfg.Ipv4PortMask |= (1 << x.EthPort)
+			cfg.Ipv4PortMask |= (1 << (x.EthPort-1))
 		}
 
 		if x.Mode == "Master" {
-			cfg.MasterPortMask |= (1 << x.EthPort)
+			cfg.MasterPortMask |= (1 << (x.EthPort-1))
 		} else if x.Mode == "Slave" {
-			cfg.SlavePortMask |= (1 << x.EthPort)
+			cfg.SlavePortMask |= (1 << (x.EthPort-1))
 		}
 	}
 }


### PR DESCRIPTION
- Looks like tsyncd is assuming ethport start by 1 instead of 0

- This affects the recalculation of SyncE,Slave, Grandmaster masks

- For instance enp81s0f2 requires ethPort: 3 and not ethPort: 2